### PR TITLE
Fixed the project favorite function

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -237,6 +237,10 @@ uaas-portal-portal-notification .container,
     background-color: #fe4039;
 }
 
+.favorite {
+    z-index: 15;
+}
+
 @media (min-width: 1280px) {
     .project-name {
         padding-bottom: 10px;


### PR DESCRIPTION
It wasn't possible to click on the star before because clicking anywhere on the env would take you to the project.
Not the greatest solution but it works.

Also, surprisingly enough, z-index: 10 wasn't enough, so it got 15 cause why not?